### PR TITLE
refactor: remove unnecessary reactivity trigger in Minesweeper

### DIFF
--- a/src/routes/engineer/minesweeper/Minesweeper.svelte
+++ b/src/routes/engineer/minesweeper/Minesweeper.svelte
@@ -67,9 +67,6 @@
 				}
 			});
 		}
-
-		// Create new Set to trigger reactivity
-		revealedBlocks = new Set(revealedBlocks);
 	}
 
 	function generateMines() {


### PR DESCRIPTION
Svelte 5's $state rune automatically tracks mutations to collections like Set.
The manual recreation of the Set (`revealedBlocks = new Set(revealedBlocks)`)
was a Svelte 4 pattern that's no longer needed and has been removed.

This makes the code cleaner and more idiomatic for Svelte 5.