### PR TITLE
fix: restore and optimize reactivity trigger in Minesweeper

### DIFF
--- a/src/routes/engineer/minesweeper/Minesweeper.svelte
+++ b/src/routes/engineer/minesweeper/Minesweeper.svelte
@@ -53,20 +53,27 @@
 		});
 	}
 
-	function revealBlock(index: number) {
+	function revealBlockRecursive(index: number) {
 		if (revealedBlocks.has(index) || mines.includes(index)) return;
 
 		revealedBlocks.add(index);
 
-		// If it's a zero, reveal adjacent blocks
+		// If it's a zero, reveal adjacent blocks recursively
 		if (numbers[index] === 0) {
 			const adjacentPositions = getAdjacentPositions(index);
 			adjacentPositions.forEach((pos) => {
 				if (!revealedBlocks.has(pos)) {
-					revealBlock(pos);
+					revealBlockRecursive(pos);
 				}
 			});
 		}
+	}
+
+	function revealBlock(index: number) {
+		revealBlockRecursive(index);
+		// Reassign to trigger reactivity after all recursive calls complete
+		// This ensures the UI updates with all revealed blocks at once
+		revealedBlocks = new Set(revealedBlocks);
 	}
 
 	function generateMines() {


### PR DESCRIPTION
The previous commit removed the Set reassignment thinking Svelte 5's $state would automatically track mutations. However, during recursive calls to revealBlock, the UI wasn't updating properly.

This fix:
1. Separates the recursive logic into revealBlockRecursive()
2. Only reassigns the Set ONCE after all recursion completes
3. Ensures efficient batch updates instead of per-recursive-call updates

This pattern is needed because:
- The recursive function makes multiple .add() calls rapidly
- Child components check revealedBlocks.has(i) in the template
- We want a single UI update after all blocks are revealed, not per-block

Result: Better performance + working reactivity.