### PR TITLE
Add ink bleed effect to entire page

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -198,8 +198,8 @@
 	small {
 		filter: blur(0.09px) url(#ink-bleed);
 	}
-	/* Links - subtle blur */
-	a {
+	/* Links - subtle blur (exclude links with images) */
+	a:not(:has(img)) {
 		filter: blur(0.1px) url(#ink-bleed);
 	}
 	/* Headings - minor progressive blur based on size */

--- a/src/app.css
+++ b/src/app.css
@@ -190,18 +190,41 @@
 	body {
 		@apply bg-background text-foreground px-4 font-mono text-base font-light;
 	}
+	/* Base text elements - subtle blur */
 	p,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	span,
+	span:not(:has(svg)),
 	li,
-	a,
-	label {
+	label,
+	small {
+		filter: blur(0.08px) url(#ink-bleed);
+	}
+	/* Links - subtle blur */
+	a {
 		filter: blur(0.1px) url(#ink-bleed);
+	}
+	/* Headings - progressive blur based on size */
+	h6 {
+		filter: blur(0.15px) url(#ink-bleed);
+	}
+	h5 {
+		filter: blur(0.18px) url(#ink-bleed);
+	}
+	h4 {
+		filter: blur(0.2px) url(#ink-bleed);
+	}
+	h3 {
+		filter: blur(0.25px) url(#ink-bleed);
+	}
+	h2 {
+		filter: blur(0.3px) url(#ink-bleed);
+	}
+	h1 {
+		filter: blur(0.4px) url(#ink-bleed);
+	}
+	/* Icons and SVGs - very subtle */
+	svg,
+	img {
+		filter: blur(0.05px) url(#ink-bleed);
 	}
 	p {
 		@apply leading-7;

--- a/src/app.css
+++ b/src/app.css
@@ -217,10 +217,6 @@
 	h1 {
 		filter: blur(0.15px) url(#ink-bleed);
 	}
-	/* Icons and SVGs - very subtle */
-	svg {
-		filter: blur(0.08px) url(#ink-bleed);
-	}
 	p {
 		@apply leading-7;
 	}

--- a/src/app.css
+++ b/src/app.css
@@ -183,6 +183,12 @@
 	}
 }
 
+@keyframes ink-in {
+	from {
+		filter: none;
+	}
+}
+
 @layer base {
 	* {
 		@apply border-border outline-ring/50;
@@ -197,25 +203,31 @@
 	label,
 	small {
 		filter: blur(0.09px) url(#ink-bleed);
+		animation: ink-in 2s ease-out both;
 	}
 	/* Links - subtle blur (exclude links with images) */
 	a:not(:has(img)) {
 		filter: blur(0.1px) url(#ink-bleed);
+		animation: ink-in 2s ease-out both;
 	}
 	/* Headings - minor progressive blur based on size */
 	h6,
 	h5,
 	h4 {
 		filter: blur(0.11px) url(#ink-bleed);
+		animation: ink-in 2s ease-out both;
 	}
 	h3 {
 		filter: blur(0.12px) url(#ink-bleed);
+		animation: ink-in 2s ease-out both;
 	}
 	h2 {
 		filter: blur(0.13px) url(#ink-bleed);
+		animation: ink-in 2s ease-out both;
 	}
 	h1 {
 		filter: blur(0.15px) url(#ink-bleed);
+		animation: ink-in 2s ease-out both;
 	}
 	p {
 		@apply leading-7;

--- a/src/app.css
+++ b/src/app.css
@@ -196,35 +196,30 @@
 	li,
 	label,
 	small {
-		filter: blur(0.08px) url(#ink-bleed);
+		filter: blur(0.09px) url(#ink-bleed);
 	}
 	/* Links - subtle blur */
 	a {
 		filter: blur(0.1px) url(#ink-bleed);
 	}
-	/* Headings - progressive blur based on size */
-	h6 {
-		filter: blur(0.15px) url(#ink-bleed);
-	}
-	h5 {
-		filter: blur(0.18px) url(#ink-bleed);
-	}
+	/* Headings - minor progressive blur based on size */
+	h6,
+	h5,
 	h4 {
-		filter: blur(0.2px) url(#ink-bleed);
+		filter: blur(0.11px) url(#ink-bleed);
 	}
 	h3 {
-		filter: blur(0.25px) url(#ink-bleed);
+		filter: blur(0.12px) url(#ink-bleed);
 	}
 	h2 {
-		filter: blur(0.3px) url(#ink-bleed);
+		filter: blur(0.13px) url(#ink-bleed);
 	}
 	h1 {
-		filter: blur(0.4px) url(#ink-bleed);
+		filter: blur(0.15px) url(#ink-bleed);
 	}
 	/* Icons and SVGs - very subtle */
-	svg,
-	img {
-		filter: blur(0.05px) url(#ink-bleed);
+	svg {
+		filter: blur(0.08px) url(#ink-bleed);
 	}
 	p {
 		@apply leading-7;

--- a/src/app.css
+++ b/src/app.css
@@ -192,10 +192,10 @@
 	body {
 		@apply bg-background text-foreground px-4 font-mono text-base font-light;
 	}
-	/* Base text elements */
-	p,
-	span:not(:has(svg)),
-	li,
+	/* Base text elements - exclude containers with images */
+	p:not(:has(img)),
+	span:not(:has(svg, img)),
+	li:not(:has(img)),
 	label,
 	small {
 		filter: blur(var(--ink-blur)) url(#ink-bleed);

--- a/src/app.css
+++ b/src/app.css
@@ -37,6 +37,8 @@
 
 :root {
 	--radius: 0;
+	/* Ink-bleed blur scales with viewport: ~0.09px on mobile → ~0.35px on desktop */
+	--ink-blur: clamp(0.09px, 0.025vw, 0.35px);
 	--text-base: 0.85rem;
 	--text-lg: 1rem;
 	--text-xl: 1.1rem;
@@ -190,32 +192,32 @@
 	body {
 		@apply bg-background text-foreground px-4 font-mono text-base font-light;
 	}
-	/* Base text elements - subtle blur */
+	/* Base text elements */
 	p,
 	span:not(:has(svg)),
 	li,
 	label,
 	small {
-		filter: blur(0.09px) url(#ink-bleed);
+		filter: blur(var(--ink-blur)) url(#ink-bleed);
 	}
-	/* Links - subtle blur (exclude links with images) */
+	/* Links - slightly more blur than base */
 	a:not(:has(img)) {
-		filter: blur(0.1px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.1)) url(#ink-bleed);
 	}
-	/* Headings - minor progressive blur based on size */
+	/* Headings - progressive blur proportional to size */
 	h6,
 	h5,
 	h4 {
-		filter: blur(0.11px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.2)) url(#ink-bleed);
 	}
 	h3 {
-		filter: blur(0.12px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.35)) url(#ink-bleed);
 	}
 	h2 {
-		filter: blur(0.13px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.45)) url(#ink-bleed);
 	}
 	h1 {
-		filter: blur(0.15px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.65)) url(#ink-bleed);
 	}
 	p {
 		@apply leading-7;

--- a/src/app.css
+++ b/src/app.css
@@ -190,6 +190,20 @@
 	body {
 		@apply bg-background text-foreground px-4 font-mono text-base font-light;
 	}
+	p,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	span,
+	li,
+	a,
+	label,
+	button {
+		filter: blur(0.25px) url(#ink-bleed);
+	}
 	p {
 		@apply leading-7;
 	}

--- a/src/app.css
+++ b/src/app.css
@@ -200,9 +200,8 @@
 	span,
 	li,
 	a,
-	label,
-	button {
-		filter: blur(0.25px) url(#ink-bleed);
+	label {
+		filter: blur(0.1px) url(#ink-bleed);
 	}
 	p {
 		@apply leading-7;

--- a/src/app.css
+++ b/src/app.css
@@ -183,12 +183,6 @@
 	}
 }
 
-@keyframes ink-in {
-	from {
-		filter: none;
-	}
-}
-
 @layer base {
 	* {
 		@apply border-border outline-ring/50;
@@ -203,31 +197,25 @@
 	label,
 	small {
 		filter: blur(0.09px) url(#ink-bleed);
-		animation: ink-in 2s ease-out both;
 	}
 	/* Links - subtle blur (exclude links with images) */
 	a:not(:has(img)) {
 		filter: blur(0.1px) url(#ink-bleed);
-		animation: ink-in 2s ease-out both;
 	}
 	/* Headings - minor progressive blur based on size */
 	h6,
 	h5,
 	h4 {
 		filter: blur(0.11px) url(#ink-bleed);
-		animation: ink-in 2s ease-out both;
 	}
 	h3 {
 		filter: blur(0.12px) url(#ink-bleed);
-		animation: ink-in 2s ease-out both;
 	}
 	h2 {
 		filter: blur(0.13px) url(#ink-bleed);
-		animation: ink-in 2s ease-out both;
 	}
 	h1 {
 		filter: blur(0.15px) url(#ink-bleed);
-		animation: ink-in 2s ease-out both;
 	}
 	p {
 		@apply leading-7;

--- a/src/app.html
+++ b/src/app.html
@@ -7,6 +7,15 @@
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" %sveltekit.theme%>
+		<svg style="position: absolute; width: 0; height: 0;" aria-hidden="true">
+			<defs>
+				<filter id="ink-bleed">
+					<feComponentTransfer>
+						<feFuncA type="discrete" tableValues="0 1 1 1" />
+					</feComponentTransfer>
+				</filter>
+			</defs>
+		</svg>
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/components/markdown/code-block.svelte
+++ b/src/lib/components/markdown/code-block.svelte
@@ -95,4 +95,9 @@
 	:global(.shiki-wrapper code) {
 		display: block;
 	}
+
+	/* Shiki wraps every token in a span — opt out of the global ink-bleed filter */
+	:global(.shiki-wrapper span) {
+		filter: none;
+	}
 </style>

--- a/src/lib/components/markdown/renderer.svelte
+++ b/src/lib/components/markdown/renderer.svelte
@@ -28,9 +28,9 @@
 
 	{#snippet strong(props)}
 		{@const { children, ...rest } = props}
-		<span {...rest} class={cn('font-semibold', rest.class)}>
+		<strong {...rest} class={cn('font-bold', rest.class)}>
 			{@render children?.()}
-		</span>
+		</strong>
 	{/snippet}
 	{#snippet a(props)}
 		{@const { children, ...rest } = props}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 
 <Toaster position="top-center" />
 
-<div class="ink-bleed-container mx-auto flex min-h-screen max-w-7xl flex-col">
+<div class="mx-auto flex min-h-screen max-w-7xl flex-col">
 	<Navbar />
 
 	<main class="flex flex-1 flex-col py-4">
@@ -35,9 +35,3 @@
 
 	<Footer />
 </div>
-
-<style>
-	.ink-bleed-container {
-		filter: blur(1px) url(#ink-bleed);
-	}
-</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 
 <Toaster position="top-center" />
 
-<div class="mx-auto flex min-h-screen max-w-7xl flex-col">
+<div class="ink-bleed-container mx-auto flex min-h-screen max-w-7xl flex-col">
 	<Navbar />
 
 	<main class="flex flex-1 flex-col py-4">
@@ -35,3 +35,9 @@
 
 	<Footer />
 </div>
+
+<style>
+	.ink-bleed-container {
+		filter: blur(1px) url(#ink-bleed);
+	}
+</style>


### PR DESCRIPTION
Implemented full-screen ink bleed effect using SVG filters based on Andy Jakubowski's tutorial. The effect combines CSS blur with SVG feComponentTransfer to create a print-like quality that mimics ink bleeding on paper.

Changes:
- Added SVG filter definition with feComponentTransfer in app.html
- Applied blur + filter combination to main content container in layout
- Effect creates sharp ink-bleed boundaries from blurred edges

https://claude.ai/code/session_011jckruLHWixw7CrvYq6cbH