### PR TITLE
Make ink-blur effect responsive to viewport size

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -192,10 +192,10 @@
 	body {
 		@apply bg-background text-foreground px-4 font-mono text-base font-light;
 	}
-	/* Base text elements */
-	p,
-	span:not(:has(svg)),
-	li,
+	/* Base text elements - exclude containers with images */
+	p:not(:has(img)),
+	span:not(:has(svg, img)),
+	li:not(:has(img)),
 	label,
 	small {
 		filter: blur(var(--ink-blur)) url(#ink-bleed);

--- a/src/app.css
+++ b/src/app.css
@@ -37,6 +37,8 @@
 
 :root {
 	--radius: 0;
+	/* Ink-bleed blur scales with viewport: ~0.09px on mobile → ~0.35px on desktop */
+	--ink-blur: clamp(0.09px, 0.025vw, 0.35px);
 	--text-base: 0.85rem;
 	--text-lg: 1rem;
 	--text-xl: 1.1rem;
@@ -190,32 +192,32 @@
 	body {
 		@apply bg-background text-foreground px-4 font-mono text-base font-light;
 	}
-	/* Base text elements - subtle blur */
+	/* Base text elements */
 	p,
 	span:not(:has(svg)),
 	li,
 	label,
 	small {
-		filter: blur(0.09px) url(#ink-bleed);
+		filter: blur(var(--ink-blur)) url(#ink-bleed);
 	}
-	/* Links - subtle blur (exclude links with images) */
+	/* Links - slightly more blur than base */
 	a:not(:has(img)) {
-		filter: blur(0.1px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.1)) url(#ink-bleed);
 	}
-	/* Headings - minor progressive blur based on size */
+	/* Headings - progressive blur proportional to size */
 	h6,
 	h5,
 	h4 {
-		filter: blur(0.11px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.2)) url(#ink-bleed);
 	}
 	h3 {
-		filter: blur(0.12px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.35)) url(#ink-bleed);
 	}
 	h2 {
-		filter: blur(0.13px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.45)) url(#ink-bleed);
 	}
 	h1 {
-		filter: blur(0.15px) url(#ink-bleed);
+		filter: blur(calc(var(--ink-blur) * 1.65)) url(#ink-bleed);
 	}
 	p {
 		@apply leading-7;


### PR DESCRIPTION
## Summary
Refactored the ink-bleed blur filter to be responsive across different viewport sizes, replacing hardcoded pixel values with a CSS custom property that scales dynamically.

## Key Changes
- Added `--ink-blur` CSS variable that uses `clamp()` to scale from ~0.09px on mobile to ~0.35px on desktop (0.025vw scaling)
- Updated all text element blur filters to use `var(--ink-blur)` as the base value instead of hardcoded pixels
- Converted heading blur values to use `calc()` multipliers relative to the base `--ink-blur` variable, maintaining the original progressive blur hierarchy:
  - Base text: 1x
  - Links: 1.1x
  - h6/h5/h4: 1.2x
  - h3: 1.35x
  - h2: 1.45x
  - h1: 1.65x

## Implementation Details
The `clamp()` function ensures the blur effect scales smoothly across all viewport sizes while maintaining readable bounds. This approach eliminates the need to maintain separate blur values for different breakpoints while preserving the intentional blur hierarchy for visual hierarchy.

https://claude.ai/code/session_01JpMuDuaAtqFw1iQBe1CqKY