### PR TITLE
Fix ink-bleed blur on bold text and shiki code tokens

### DIFF
--- a/src/lib/components/markdown/code-block.svelte
+++ b/src/lib/components/markdown/code-block.svelte
@@ -95,4 +95,9 @@
 	:global(.shiki-wrapper code) {
 		display: block;
 	}
+
+	/* Shiki wraps every token in a span — opt out of the global ink-bleed filter */
+	:global(.shiki-wrapper span) {
+		filter: none;
+	}
 </style>

--- a/src/lib/components/markdown/renderer.svelte
+++ b/src/lib/components/markdown/renderer.svelte
@@ -28,9 +28,9 @@
 
 	{#snippet strong(props)}
 		{@const { children, ...rest } = props}
-		<span {...rest} class={cn('font-semibold', rest.class)}>
+		<strong {...rest} class={cn('font-bold', rest.class)}>
 			{@render children?.()}
-		</span>
+		</strong>
 	{/snippet}
 	{#snippet a(props)}
 		{@const { children, ...rest } = props}


### PR DESCRIPTION
- strong: switch from <span class="font-semibold"> to <strong class="font-bold">
  so bold text uses the correct semantic element and is no longer caught
  by the span ink-bleed filter rule, restoring readability on mobile
- code-block: add filter: none to .shiki-wrapper span so shiki's per-token spans are excluded from the global ink-bleed blur, keeping code sharp

https://claude.ai/code/session_01JpMuDuaAtqFw1iQBe1CqKY