### PR TITLE
fix: prevent ink-bleed double-filtering on block-level anchor containers

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -200,8 +200,13 @@
 	small {
 		filter: blur(var(--ink-blur)) url(#ink-bleed);
 	}
-	/* Links - slightly more blur than base */
-	a:not(:has(img)) {
+	/* Links - slightly more blur than base.
+	   Exclude block-level containers (cards with heading/paragraph children) to prevent
+	   double-filtering: child h2/p elements get their own ink-bleed filter via the rules
+	   above. Applying it again on the container creates a stacking context that causes
+	   Safari to re-composite the already-filtered children during hover transitions,
+	   making text appear blurry instead of showing the subtle ink-bleed texture. */
+	a:not(:has(img, h1, h2, h3, h4, h5, h6, p)) {
 		filter: blur(calc(var(--ink-blur) * 1.1)) url(#ink-bleed);
 	}
 	/* Headings - progressive blur proportional to size */


### PR DESCRIPTION
Exclude <a> elements that contain heading or paragraph descendants from
the ink-bleed filter rule. Card links (like the /engineer project cards)
are block-level containers whose h2/p children already receive ink-bleed
individually. Applying the filter again on the container creates a CSS
stacking context that causes Safari to re-composite the already-filtered
children during hover transitions (transition-colors), making text appear
blurry rather than showing the subtle ink-bleed texture.

Inline links that wrap plain text are unaffected since they don't contain
h1–h6 or p descendants.

https://claude.ai/code/session_01EXaupABRd2ZTvznrXgywvL