### PR TITLE
Add permanent redirects for legacy paths and www host

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,64 +1,102 @@
 {
-	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"buildCommand": "vite build",
-	"devCommand": "vite dev",
-	"headers": [
-		{
-			"source": "/(.*)",
-			"headers": [
-				{
-					"key": "X-Frame-Options",
-					"value": "SAMEORIGIN"
-				},
-				{
-					"key": "X-Content-Type-Options",
-					"value": "nosniff"
-				},
-				{
-					"key": "Referrer-Policy",
-					"value": "no-referrer"
-				},
-				{
-					"key": "Permissions-Policy",
-					"value": "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
-				},
-				{
-					"key": "Cross-Origin-Embedder-Policy",
-					"value": "require-corp"
-				},
-				{
-					"key": "Cross-Origin-Opener-Policy",
-					"value": "same-origin"
-				},
-				{
-					"key": "Cross-Origin-Resource-Policy",
-					"value": "same-origin"
-				},
-				{
-					"key": "Origin-Agent-Cluster",
-					"value": "?1"
-				},
-				{
-					"key": "X-DNS-Prefetch-Control",
-					"value": "off"
-				},
-				{
-					"key": "X-Download-Options",
-					"value": "noopen"
-				},
-				{
-					"key": "X-Permitted-Cross-Domain-Policies",
-					"value": "none"
-				},
-				{
-					"key": "X-XSS-Protection",
-					"value": "0"
-				},
-				{
-					"key": "Access-Control-Allow-Origin",
-					"value": "https://quang.design"
-				}
-			]
-		}
-	]
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "vite build",
+  "devCommand": "vite dev",
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.quang.design"
+        }
+      ],
+      "destination": "https://quang.design/$1",
+      "permanent": true
+    },
+    {
+      "source": "/ai",
+      "destination": "/engineer",
+      "permanent": true
+    },
+    {
+      "source": "/dev/telescopic",
+      "destination": "/engineer/telescopic",
+      "permanent": true
+    },
+    {
+      "source": "/dev/microscopic",
+      "destination": "/engineer/microscopic",
+      "permanent": true
+    },
+    {
+      "source": "/blog/this-design-look-sad",
+      "destination": "/blog/posts/this-design-look-sad",
+      "permanent": true
+    },
+    {
+      "source": "/blog/security-headers-sveltekit",
+      "destination": "/blog/posts/security-headers-sveltekit",
+      "permanent": true
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Origin-Agent-Cluster",
+          "value": "?1"
+        },
+        {
+          "key": "X-DNS-Prefetch-Control",
+          "value": "off"
+        },
+        {
+          "key": "X-Download-Options",
+          "value": "noopen"
+        },
+        {
+          "key": "X-Permitted-Cross-Domain-Policies",
+          "value": "none"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "0"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "https://quang.design"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation
- Recover pages that returned 404s in Google Search Console by adding permanent redirects and enforce a single canonical host (`www.quang.design` → `quang.design`).

### Description
- Add a `redirects` array to `vercel.json` that includes a host-based redirect from `www.quang.design/(.*)` to `https://quang.design/$1` and permanent redirects for legacy paths: `/ai` → `/engineer`, `/dev/telescopic` → `/engineer/telescopic`, `/dev/microscopic` → `/engineer/microscopic`, `/blog/this-design-look-sad` → `/blog/posts/this-design-look-sad`, and `/blog/security-headers-sveltekit` → `/blog/posts/security-headers-sveltekit`.
- Preserve the existing `headers` configuration in `vercel.json` and make no other runtime changes.

### Testing
- Verified `vercel.json` is valid JSON using `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8'))"`; this succeeded.
- Attempted a production build with `pnpm build` to validate the site, which failed due to a missing private environment export (`ANTHROPIC_API_KEY`) unrelated to the redirect changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b567babeec832fac361860a1ab5707)