### PR TITLE
Remove host-based www redirect to fix homepage redirect loop

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,17 +4,6 @@
   "devCommand": "vite dev",
   "redirects": [
     {
-      "source": "/(.*)",
-      "has": [
-        {
-          "type": "host",
-          "value": "www.quang.design"
-        }
-      ],
-      "destination": "https://quang.design/$1",
-      "permanent": true
-    },
-    {
       "source": "/ai",
       "destination": "/engineer",
       "permanent": true


### PR DESCRIPTION
### Motivation
- A host-based redirect from `www.quang.design` to `quang.design` in `vercel.json` was creating a redirect loop for homepage requests and needed to be removed so Vercel domain settings can handle canonicalization.

### Description
- Removed the host-based redirect rule from `vercel.json` while keeping all existing path redirects (e.g. `/ai`, `/dev/*`, legacy blog URLs) and the global response headers intact.

### Testing
- Verified `vercel.json` parses successfully with `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8'))"` which succeeded.  
- Attempted `pnpm build`; the build started but did not complete within the execution environment before being stopped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b576ffdfc0832f91f5f9b4b968e962)