### PR TITLE
Fix email subscribe capture

### DIFF
--- a/src/lib/components/shared/subscribe.svelte
+++ b/src/lib/components/shared/subscribe.svelte
@@ -27,7 +27,7 @@
 				toast.error(`Subscription failed: ${errorMessage}`);
 				return;
 			}
-			toast.success('Successfully subscribed!');
+			toast.success('Email captured — thank you!');
 			email = '';
 		} finally {
 			loading = false;
@@ -38,6 +38,6 @@
 <form action="" onsubmit={handleSubmit} class="flex items-center gap-2">
 	<Input name="email" type="email" placeholder="Enter your email" bind:value={email} required />
 	<Button type="submit" variant="default" disabled={loading}
-		>{loading ? 'Subscribing...' : 'Subscribe'}</Button
+		>{loading ? 'Capturing...' : 'Subscribe'}</Button
 	>
 </form>

--- a/src/lib/utils/resend.ts
+++ b/src/lib/utils/resend.ts
@@ -1,22 +1,47 @@
+import { env } from '$env/dynamic/private';
 import { Resend } from 'resend';
-import { RESEND_API_KEY, RESEND_AUDIENCE_ID } from '$env/static/private';
 
-const resend = new Resend(RESEND_API_KEY);
+const resend = new Resend(env.RESEND_API_KEY);
+const defaultNotificationEmail = 'xinchao@quang.design';
 
-export async function addContact(email: string) {
-	if (!RESEND_AUDIENCE_ID) {
-		throw new Error('Missing RESEND_AUDIENCE_ID environment variable');
+export class SubscribeError extends Error {
+	statusCode: number;
+
+	constructor(message: string, statusCode = 500, name = 'subscription_error') {
+		super(message);
+		this.name = name;
+		this.statusCode = statusCode;
 	}
+}
 
-	const result = await resend.contacts.create({
-		email: email.toLowerCase().trim(),
-		unsubscribed: false,
-		audienceId: RESEND_AUDIENCE_ID
+function escapeHtml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;');
+}
+
+export async function sendSubscriptionNotification(email: string) {
+	const subscriberEmail = email.toLowerCase().trim();
+	const notificationEmail = env.SUBSCRIBE_NOTIFICATION_TO || defaultNotificationEmail;
+	const sentAt = new Date().toISOString();
+	const safeEmail = escapeHtml(subscriberEmail);
+	const safeSentAt = escapeHtml(sentAt);
+
+	const result = await resend.emails.send({
+		from: env.SUBSCRIBE_NOTIFICATION_FROM || `Quang Design <${defaultNotificationEmail}>`,
+		to: notificationEmail,
+		replyTo: subscriberEmail,
+		subject: `New subscriber: ${subscriberEmail}`,
+		text: `New email subscriber: ${subscriberEmail}\nSubmitted at: ${sentAt}`,
+		html: `<p>New email subscriber:</p><p><strong>${safeEmail}</strong></p><p>Submitted at: ${safeSentAt}</p>`
 	});
 
 	if (!result.error) {
 		return result;
 	}
 
-	throw new Error(result.error.message);
+	throw new SubscribeError(result.error.message, result.error.statusCode ?? 500, result.error.name);
 }

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -1,4 +1,4 @@
-import { addContact } from '$lib/utils/resend';
+import { sendSubscriptionNotification, SubscribeError } from '$lib/utils/resend';
 import type { RequestHandler } from '@sveltejs/kit';
 import { z } from 'zod';
 
@@ -35,15 +35,15 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		const email = parsed.data.email.trim();
 
-		const result = await addContact(email);
+		const result = await sendSubscriptionNotification(email);
 		return new Response(JSON.stringify({ success: true, result }), {
 			status: 200,
 			headers: { 'Content-Type': 'application/json' }
 		});
-	} catch (err: any) {
-		const status = err?.statusCode ?? 500;
-		const message = err?.message ?? 'Failed to subscribe email.';
-		const name = err?.name ?? 'internal_error';
+	} catch (err: unknown) {
+		const status = err instanceof SubscribeError ? err.statusCode : 500;
+		const message = err instanceof Error ? err.message : 'Failed to capture email.';
+		const name = err instanceof Error ? err.name : 'internal_error';
 		return new Response(JSON.stringify({ name, message, statusCode: status }), {
 			status,
 			headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Summary
- Replaces Resend audience contact creation with a send-only Resend notification email for new subscribers.
- Sends captured email submissions to `SUBSCRIBE_NOTIFICATION_TO`, defaulting to `xinchao@quang.design`.
- Allows overriding the sender with `SUBSCRIBE_NOTIFICATION_FROM`, defaulting to `Quang Design <xinchao@quang.design>`.
- Updates subscribe UI copy from “subscribed” to “email captured” to match the new behavior.
- Improves subscribe API error handling by avoiding `any` and returning Resend status/name when available.

## Review & Testing Checklist for Human
- [x] Confirm `xinchao@quang.design` is the right fallback inbox and valid Resend sender; set `SUBSCRIBE_NOTIFICATION_TO` / `SUBSCRIBE_NOTIFICATION_FROM` in production if not.
- [x] Submit a real email on the deployed preview/production site and verify the notification email arrives with the submitted address in the body and reply-to.
- [x] Confirm this notification-based capture is acceptable versus storing contacts in a Resend audience or database.

### Notes
- Local checks run: `pnpm lint`, `ANTHROPIC_API_KEY=dummy pnpm check`, `pnpm test`.
- The original failure was caused by the API key being restricted to sending emails, so this avoids Resend contact/audience APIs.

Link to Devin session: https://app.devin.ai/sessions/0a6e85fc554c434e857144b5e3e4caab
Requested by: @quang-design